### PR TITLE
Initialize working directory for ACID tests

### DIFF
--- a/test/private/initializeWorkingDirectory.m
+++ b/test/private/initializeWorkingDirectory.m
@@ -1,0 +1,23 @@
+function cwd = initializeWorkingDirectory()
+% Initialize working directory. Change into 'test' folder of matlab2tikz.
+% Return current working directory so that after tests it can be restored.
+    fprintf('Initialize working directory...\n');
+    cwd = pwd;
+    m2t_path = which('matlab2tikz.m');
+    bSuccess = 0;
+    
+    if ~isempty(m2t_path)
+        test_path = fullfile(fileparts(m2t_path), '..', 'test');
+        
+        if isdir(test_path)
+            cd(test_path);
+            fprintf('Successfully changed into test folder...\n');
+            bSuccess = 1;
+        end
+    end
+    
+    if ~bSuccess
+        error('matlab2tikz:initializeWorkingDirectory', ...
+            'Could not change into test folder.');
+    end
+end

--- a/test/testGraphical.m
+++ b/test/testGraphical.m
@@ -14,6 +14,7 @@ function [ status ] = testGraphical( varargin )
 %
 % See also: testMatlab2tikz, testHeadless, makeLatexReport
 
+    cwd = initializeWorkingDirectory();
     status = testMatlab2tikz('actionsToExecute', @actionsToExecute, ...
                              varargin{:});
 
@@ -21,6 +22,7 @@ function [ status ] = testGraphical( varargin )
         makeLatexReport(status);
     end
 
+    cd(cwd);    % return to previous working directory
 end
 % ==============================================================================
 function status = actionsToExecute(status, ipp)

--- a/test/testHeadless.m
+++ b/test/testHeadless.m
@@ -23,6 +23,7 @@ function [ status ] = testHeadless( varargin )
                     'floatFormat', '%8.6g'  ,...
                    };
 
+    cwd = initializeWorkingDirectory();
     status = testMatlab2tikz('extraOptions', extraOptions, ...
                              'actionsToExecute', @actionsToExecute, ...
                              varargin{:});
@@ -31,6 +32,7 @@ function [ status ] = testHeadless( varargin )
         makeTravisReport(status);
     end
 
+    cd(cwd);    % return to previous working directory
 end
 % ==============================================================================
 function status = actionsToExecute(status, ipp)


### PR DESCRIPTION
Fail with a descriptive error, if tests could not be executed in the proper directory. The path is determined by locating `matlab2tikz.m`.
This addresses the open todo in PR https://github.com/matlab2tikz/matlab2tikz/pull/485.
